### PR TITLE
Add support for centos and friends

### DIFF
--- a/files/tasseo.init
+++ b/files/tasseo.init
@@ -1,0 +1,107 @@
+#!/bin/sh
+#
+# tasseo          live dashboard for graphite
+#
+# chkconfig: 345 95 5
+# description: 		live dashboard for graphite
+#
+ 
+### BEGIN INIT INFO
+# Provides:          NAME
+# Required-Start:    $network
+# Required-Stop:     $network
+# Description:       live dashboard for graphite
+# Short-Description: live dashboard for graphite
+### END INIT INFO
+
+[ -f /etc/sysconfig/tasseo ] &&  . /etc/sysconfig/tasseo
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+NAME=tasseo
+
+DESC=tasseo
+DIR=/opt/tasseo 
+LOCK_FILE=/var/lock/subsys/$NAME
+PID_FILE=/var/run/$NAME.pid
+CONTROL="bundle exec thin -R config.ru -p $PORT -d -P $PID_FILE"
+
+RETVAL=0
+set -e
+ 
+start () {
+    set +e
+	cd $DIR
+    OUTPUT=$($CONTROL start) 
+    echo $OUTPUT | grep -q 'ERROR' 
+    STARTSTATUS=$?
+    set -e
+    case "$STARTSTATUS" in
+        1)
+            echo SUCCESS
+            if [ -n "$LOCK_FILE" ] ; then
+                touch $LOCK_FILE
+            fi
+            RETVAL=0
+            ;;
+        *)
+            echo FAILED
+            echo $OUTPUT
+            RETVAL=1
+            ;;
+    esac
+}
+ 
+stop () {
+        set +e
+		cd $DIR
+	    OUTPUT=$($CONTROL stop) 
+        RETVAL=$?
+        set -e
+        if [ $RETVAL = 0 ] ; then
+            echo SUCCESS
+            if [ -n "$LOCK_FILE" ] ; then
+                rm -f $LOCK_FILE
+            fi
+        else
+            echo FAILED
+        fi
+}
+ 
+status() {
+    set +e
+    OUTPUT=$(kill -0 `cat $PID_FILE`)
+	RETVAL=$?
+    if [ $RETVAL = 0 ] ; then
+        echo "$NAME running"
+    fi
+    set -e
+}
+ 
+restart() {
+    stop
+    start
+}
+ 
+case "$1" in
+    start)
+        echo -n "Starting $DESC: "
+        start
+        ;;
+    stop)
+        echo -n "Stopping $DESC: "
+        stop
+        ;;
+    restart)
+        echo -n "Restarting $DESC: "
+        restart
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart}" >&2
+        RETVAL=1
+        ;;
+esac
+ 
+exit $RETVAL

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,2 +1,8 @@
 class tasseo::config {
+
+  file { $tasseo::params::config_file:
+    ensure  => present,
+    content => $tasseo::params::config_content
+  }
+
 }

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -1,0 +1,8 @@
+class tasseo::debian {
+
+  file { '/etc/init.d/tasseo':
+    ensure => link,
+    target => '/lib/init/upstart-job',
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class tasseo (
   $graphite_auth = false,
   $port = 5000
 ){
+  class{'tasseo::params': } ->
   class{'tasseo::install': } ->
   class{'tasseo::config': } ~>
   class{'tasseo::service': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,4 +8,11 @@ class tasseo (
   class{'tasseo::config': } ~>
   class{'tasseo::service': } ->
   Class['tasseo']
+
+  case $::operatingsystem {
+    /(?i:CentOS|RedHat|Fedora)/:  { class {'tasseo::redhat': } }
+    /(?i:Ubuntu|Debian|Mint)/:    { class {'tasseo::debian': } }
+    default:                      { }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
-class tasseo(
+class tasseo (
   $graphite_url = 'http://localhost:8081',
   $graphite_auth = false,
-  $port = 5000,
+  $port = 5000
 ){
   class{'tasseo::install': } ->
   class{'tasseo::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,23 @@
+class tasseo::params {
+
+  $service_require = $::operatingsystem ? {
+    /(?i:Ubuntu|Debian|Mint)/ => Class['tasseo::debian'],
+    default                   => Class['tasseo::redhat']
+  }
+
+  $service_provider = $::operatingsystem ? {
+    /(?i:Ubuntu|Debian|Mint)/ => upstart,
+    default                   => redhat
+  }
+
+  $config_file = $::operatingsystem ? {
+    /(?i:Ubuntu|Debian|Mint)/ => '/etc/init/tasseo.conf',
+    default                   => '/etc/sysconfig/tasseo'
+  }
+
+  $config_content = $::operatingsystem ? {
+    /(?i:Ubuntu|Debian|Mint)/ => template('tasseo/etc/init/tasseo.conf.erb'),
+    default                   => template('tasseo/etc/sysconfig/tasseo.erb')
+  }
+
+}

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -1,0 +1,9 @@
+class tasseo::redhat {
+
+  file { '/etc/rc.d/init.d/tasseo':
+    ensure => present,
+    source => 'puppet:///modules/tasseo/tasseo.init',
+    mode   => '0755'
+  }
+
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,10 +13,10 @@ class tasseo::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
-    provider   => upstart,
     require    => [
       File['/etc/init.d/tasseo'],
       File['/etc/init/tasseo.conf'],
     ],
+    provider   => $tasseo::params::service_provider,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,4 @@
 class tasseo::service {
-  $graphite_url = $tasseo::graphite_url
-  $graphite_auth = $tasseo::graphite_auth
-  $port = $tasseo::port
 
   service { 'tasseo':
     ensure     => running,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,11 +8,6 @@ class tasseo::service {
     target => '/lib/init/upstart-job',
   }
 
-  file { '/etc/init/tasseo.conf':
-    ensure  => present,
-    content => template('tasseo/etc/init/tasseo.conf.erb'),
-  }
-
   service { 'tasseo':
     ensure     => running,
     enable     => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,10 +13,7 @@ class tasseo::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
-    require    => [
-      File['/etc/init.d/tasseo'],
-      File['/etc/init/tasseo.conf'],
-    ],
     provider   => $tasseo::params::service_provider,
+    require    => [$tasseo::params::service_require, Class['tasseo::config']]
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,11 +3,6 @@ class tasseo::service {
   $graphite_auth = $tasseo::graphite_auth
   $port = $tasseo::port
 
-  file { '/etc/init.d/tasseo':
-    ensure => link,
-    target => '/lib/init/upstart-job',
-  }
-
   service { 'tasseo':
     ensure     => running,
     enable     => true,

--- a/spec/classes/tasseo/tasseo_spec.rb
+++ b/spec/classes/tasseo/tasseo_spec.rb
@@ -2,10 +2,15 @@ require 'spec_helper'
 
 describe 'tasseo', :type => :class do
 
-  context 'no parameters' do
+  context 'no parameters on Ubuntu' do
+    let :facts do
+      { :operatingsystem => 'Ubuntu' }
+    end
     it { should create_class('tasseo::config')}
     it { should create_class('tasseo::install')}
     it { should create_class('tasseo::service')}
+    it { should create_class('tasseo::debian')}
+
 
     it { should contain_file('/etc/init/tasseo.conf').with_content(/PORT=5000/)}
     it { should_not contain_file('/etc/init/tasseo.conf').with_content(/GRAPHITE_AUTH=/)}
@@ -13,18 +18,51 @@ describe 'tasseo', :type => :class do
     it { should contain_service('tasseo').with_ensure('running').with_enable('true') }
   end
 
-  context 'with a custom graphite host' do
+  context 'no parameters on CentOS' do
+    let :facts do
+      { :operatingsystem => 'CentOS' }
+    end
+    it { should create_class('tasseo::config')}
+    it { should create_class('tasseo::install')}
+    it { should create_class('tasseo::service')}
+    it { should create_class('tasseo::redhat')}
+
+
+    it { should contain_file('/etc/sysconfig/tasseo').with_content(/PORT=5000/)}
+    it { should_not contain_file('/etc/sysconfig/tasseo').with_content(/GRAPHITE_AUTH=/)}
+    it { should contain_file('/etc/rc.d/init.d/tasseo')}
+    it { should contain_service('tasseo').with_ensure('running').with_enable('true') }
+  end
+
+  context 'with a custom graphite host on Ubuntu' do
+    let :facts do
+      { :operatingsystem => 'Ubuntu' }
+    end
     let(:params) { {'graphite_url' => 'http://graphite.example.com'} }
     it { should contain_file('/etc/init/tasseo.conf').with_content(/GRAPHITE_URL=http:\/\/graphite.example.com/)}
   end
 
-  context 'with a custom port' do
+  context 'with a custom graphite host on CentOS' do
+    let :facts do
+      { :operatingsystem => 'CentOS' }
+    end
+    let(:params) { {'graphite_url' => 'http://graphite.example.com'} }
+    it { should contain_file('/etc/sysconfig/tasseo').with_content(/GRAPHITE_URL=http:\/\/graphite.example.com/)}
+  end
+
+  context 'with a custom port on Ubuntu' do
+    let :facts do
+      { :operatingsystem => 'Ubuntu' }
+    end
     let(:params) { {'port' => 5001} }
     it { should contain_file('/etc/init/tasseo.conf').with_content(/PORT=5001/)}
   end
 
-  context 'with a custom graphite host' do
+  context 'with a custom graphite host on CentOS' do
+    let :facts do
+      { :operatingsystem => 'CentOS' }
+    end
     let(:params) { {'graphite_auth' => 'user:password'} }
-    it { should contain_file('/etc/init/tasseo.conf').with_content(/GRAPHITE_AUTH=user:password/)}
+    it { should contain_file('/etc/sysconfig/tasseo').with_content(/GRAPHITE_AUTH=user:password/)}
   end
 end

--- a/templates/etc/init/tasseo.conf.erb
+++ b/templates/etc/init/tasseo.conf.erb
@@ -7,10 +7,10 @@ stop on runlevel [06]
 respawn
 respawn limit 5 30
 
-env GRAPHITE_URL=<%= graphite_url %>
-env PORT=<%= port %>
+env GRAPHITE_URL=<%= scope.lookupvar('tasseo::graphite_url') %>
+env PORT=<%= scope.lookupvar('tasseo::port') %>
 
-<% if graphite_auth %>env GRAPHITE_AUTH=<%= graphite_auth %><% end %>
+<% if scope.lookupvar('tasseo::graphite_auth') %>env GRAPHITE_AUTH=<%= scope.lookupvar('tasseo::graphite_auth') %><% end %>
 
 chdir /opt/tasseo
 setuid www-data

--- a/templates/etc/sysconfig/tasseo.erb
+++ b/templates/etc/sysconfig/tasseo.erb
@@ -1,0 +1,3 @@
+GRAPHITE_URL=<%= scope.lookupvar('tasseo::graphite_url') %>
+PORT=<%= scope.lookupvar('tasseo::port') %>
+<% if scope.lookupvar('tasseo::graphite_auth') %>GRAPHITE_AUTH=<%= scope.lookupvar('tasseo::graphite_auth') %><% end %>


### PR DESCRIPTION
Had to do a number of things to allow for multi distribution support
- Create params class and abstract as many distro specific settings as possible into there
- Add tasseo::redhat and tasseo::debian class for init script because the file resource is so different between upstart and init (link vs file)
- Add redhat init script and config file
